### PR TITLE
Fix/#200 환경변수 적용 문제 해결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,10 +58,14 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
         with:
           args: |
-            ✅ **[배포 성공]**
-            S3 + CloudFront 배포가 완료되었습니다. 🎉  
-            브랜치: `${{ github.ref_name }}`  
-            커밋: `${{ github.sha }}`
+            🟢 **프론트 배포 성공!**
+
+            🎉 S3 + CloudFront 배포가 완료되었습니다!
+
+            📦 브랜치 : `${{ github.ref_name }}`
+            🔗 커밋   : `${{ github.sha }}`
+
+            🔍 [Actions 실행 로그 보기](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
 
       - name: Send failure message to Discord
         if: failure()
@@ -70,7 +74,11 @@ jobs:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
         with:
           args: |
-            ❌ **[배포 실패]**
-            오류가 발생해 배포에 실패했습니다. 🔥  
-            커밋: `${{ github.sha }}`  
-            👉 [로그 확인](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            🔴 **프론트 배포 실패!**
+
+            ⚠️ S3 + CloudFront 배포 중 오류가 발생했습니다.
+
+            📦 브랜치 : `${{ github.ref_name }}`
+            🔗 커밋   : `${{ github.sha }}`
+
+            🚨 [오류 로그 확인하기](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Create .env.production
+        run: |
+          echo "VITE_API_URL=${{ secrets.VITE_API_URL }}" >> .env.production
+          echo "VITE_API_V1=${{ secrets.VITE_API_V1 }}" >> .env.production
+          echo "VITE_GOOGLE_CLIENT_ID=${{ secrets.VITE_GOOGLE_CLIENT_ID }}" >> .env.production
+          echo "VITE_GITHUB_CLIENT_ID=${{ secrets.VITE_GITHUB_CLIENT_ID }}" >> .env.production
+          echo "VITE_KAKAO_CLIENT_ID=${{ secrets.VITE_KAKAO_CLIENT_ID }}" >> .env.production
+          echo "VITE_OAUTH_BASE_URL=${{ secrets.VITE_OAUTH_BASE_URL }}" >> .env.production
+          echo "VITE_YORKIE_URL=${{ secrets.VITE_YORKIE_URL }}" >> .env.production
+          echo "VITE_YORKIE_API_KEY=${{ secrets.VITE_YORKIE_API_KEY }}" >> .env.production
+
       - name: Build
         run: npm run build
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

close #200 

<br/>

## 🔎 작업 내용

- GitHub Secrets에 환경변수 설정
- deploy 파일 수정

로컬에서는 .env.production 파일을 사용해 빌드 시 환경변수를 주입하지만, GitHub Actions는 GitHub의 CI 서버에서 실행되므로 .env.production 파일이 존재하지 않습니다.

즉, VITE_API_URL, VITE_GOOGLE_CLIENT_ID 등 .env.production에 정의된 환경변수들이 없기 때문에, Vite 빌드가 실패하거나 잘못된 값이 들어가 현재 배포된 사이트에서 에러가 발생합니다. 이 부분 GitHub Secrets에 환경변수를 설정하는 것으로 해결했습니다.

<br/>

## 이미지 첨부(선택)

<br/>

## 💬 리뷰 요구사항(선택)

